### PR TITLE
Update winged flyer to 1.5 and to use VFE abilities

### DIFF
--- a/1.5/Defs/AbilityDefs/Abilites/Abilities.xml
+++ b/1.5/Defs/AbilityDefs/Abilites/Abilities.xml
@@ -42,7 +42,7 @@
 	 <ThingDef>
 		<defName>WingedFlyer</defName>
 		<label>dragon in flight</label>
-		<thingClass>VFECore.Abilities.AbilityPawnFlyer</thingClass>
+		<thingClass>DD.WingedFlyer</thingClass>
 		<category>Ethereal</category>
 		<tickerType>Normal</tickerType>
 		<altitudeLayer>Weather</altitudeLayer>

--- a/1.5/Defs/AbilityDefs/Abilites/DragonBreath_VFECore.Abilities.xml
+++ b/1.5/Defs/AbilityDefs/Abilites/DragonBreath_VFECore.Abilities.xml
@@ -224,4 +224,45 @@
         </modExtensions>
       </VFECore.Abilities.AbilityDef> -->
 
+
+    <VFECore.Abilities.AbilityDef>
+        <defName>DD_DraconicFlight</defName>
+        <label>winged flight</label>
+        <description>Jet goes up, Icarus comes down.</description>
+        <abilityClass>DD.Ability_WingedFlyer</abilityClass>
+        <targetMode>Location</targetMode>
+        <targetingParameters>
+            <canTargetPawns>true</canTargetPawns>
+            <canTargetLocations>true</canTargetLocations>
+        </targetingParameters>
+        <iconPath>UserInterface/Abilities/Fly</iconPath>
+        <cooldownTime>5200</cooldownTime>
+        <castTime>60</castTime>
+        <!-- 40 doesn't allow targeting all highlighted tiles, so a slightly bigger value is needed. -->
+        <range>40.01</range>
+        <showUndrafted>true</showUndrafted>
+        <requireLineOfSight>false</requireLineOfSight>
+
+        <modExtensions>
+            <!-- Require wings to use, just like it worked previously. -->
+            <li Class="DD.RequireBodyPartExtension">
+                <missing>true</missing>
+                <bodyPart>Wing</bodyPart>
+            </li>
+            <li Class="DD.WingedFlyerAbilityExtension">
+                <!-- Currently DD will automatically use WingedFlyer, but a custom flyer will be needed if made standalone. -->
+                <flyerDef>WingedFlyer</flyerDef>
+                <!-- Defaults to false, if true will skip the check for roof. -->
+                <ignoreRoofCheck>false</ignoreRoofCheck>
+                <!-- If present, this is the messages that will be displayed when trying to fly while under a roof/targeting a tile under a roof. -->
+                <!-- If not set/left empty only a sound will be played. -->
+                <underRoofStartKey>Ability_CannotStartFlyingUnderRoof</underRoofStartKey>
+                <underRoofEndKey>Ability_CannotEndFlyingUnderRoof</underRoofEndKey>
+            </li>
+            <!-- Prevent use of the ability while forming caravan, just like it worked in the past. -->
+            <!-- disableMessageKey will default to Ability_CannotUseWhileFormingCaravan -->
+            <li Class="DD.CannotUseWhileFormingCaravanExtension" />
+        </modExtensions>
+    </VFECore.Abilities.AbilityDef>
+
 </Defs>

--- a/1.5/Defs/ThingDefs_Races/Races_Animal_Common_Dragon.xml
+++ b/1.5/Defs/ThingDefs_Races/Races_Animal_Common_Dragon.xml
@@ -137,7 +137,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -175,7 +175,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -321,6 +321,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -458,7 +459,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -496,7 +497,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -636,6 +637,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -773,7 +775,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>16</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -811,7 +813,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -950,6 +952,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -1107,7 +1110,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -1145,7 +1148,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -1284,6 +1287,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -1425,7 +1429,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -1463,7 +1467,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -1603,6 +1607,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -1760,7 +1765,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -1798,7 +1803,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -1937,6 +1942,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -2095,7 +2101,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -2133,7 +2139,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -2272,6 +2278,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>

--- a/1.5/Defs/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
+++ b/1.5/Defs/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
@@ -134,7 +134,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -166,7 +166,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -301,6 +301,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -440,7 +441,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -472,7 +473,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -607,6 +608,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -741,7 +743,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -773,7 +775,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -908,6 +910,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>
@@ -1091,7 +1094,7 @@
       </wildBiomes>
     </race>
     <modExtensions>
-      <!-- <li Class="DD.WingedFlyerExtension">
+      <li Class="DD.WingedFlyerExtension">
         <flightSpeed>14</flightSpeed>
         <flyingGraphicData Class="DD.AnimationGraphicData">
           <texPath>Things/Pawn/Animal/Flight</texPath>
@@ -1123,7 +1126,7 @@
             </variantData>
           </li>
         </variants>
-      </li> -->
+      </li>
       <li Class="DD.CarryCapacityExtension">
         <constant>360</constant>
         <offset>100</offset>
@@ -1258,6 +1261,7 @@
           <li>DD_DragonJump</li>
           <li>DD_DragonBreath_Fire</li>
           <li>DD_DragonSpit_Fire</li>
+          <li>DD_DraconicFlight</li>
         </giveAbilities>
         <giveRandomAbilities>false</giveRandomAbilities>
       </li>

--- a/1.5/Languages/English/Keyed/Abilities.xml
+++ b/1.5/Languages/English/Keyed/Abilities.xml
@@ -9,5 +9,8 @@
 	<Ability_NotifyMapGenocide>All pawns on the map will be killed and the map will be destroyed!</Ability_NotifyMapGenocide>
 	
 	<Ability_RequiresBodyPart>{PAWN} is missing ({COUNT}) {BODYPART}.</Ability_RequiresBodyPart>
+	<Ability_CannotUseWhileFormingCaravan>{PAWN} cannot use this ability while forming a caravan.</Ability_CannotUseWhileFormingCaravan>
+	<Ability_CannotStartFlyingUnderRoof>Cannot fly when under a roof.</Ability_CannotStartFlyingUnderRoof>
+	<Ability_CannotEndFlyingUnderRoof>Cannot target a roofed tile.</Ability_CannotEndFlyingUnderRoof>
 	
 </LanguageData>

--- a/1.5/Source/DDLib/Abilities/Ability_WingedFlyer.cs
+++ b/1.5/Source/DDLib/Abilities/Ability_WingedFlyer.cs
@@ -1,0 +1,68 @@
+﻿using RimWorld;
+using RimWorld.Planet;
+using Verse;
+using Verse.Sound;
+using Ability = VFECore.Abilities.Ability;
+
+namespace DD;
+
+public class Ability_WingedFlyer : Ability
+{
+    public WingedFlyerAbilityExtension Extension => def.GetModExtension<WingedFlyerAbilityExtension>();
+    
+    public override void Cast(params GlobalTargetInfo[] targets)
+    {
+        base.Cast(targets);
+
+        // Mostly meaningless as the ability def should enforce proper targets here,
+        // so the check for any target non-global is here for extra safety.
+        if (targets.Length > 0 && !targets[0].IsWorldTarget)
+        {
+            // Inside DD the flyer can depend on the DD defs.
+            // If the flyer would be extracted into a standalone .dll file, it can't depend on it
+            // and needs to use a separate def for the flyer.
+            WingedFlyer.MakeFlyer(CasterPawn, (TargetInfo)targets[0], Extension?.flyerDef ?? DD_ThingDefOf.WingedFlyer);
+        }
+    }
+
+    public override bool ValidateTarget(LocalTargetInfo target, bool showMessages = true)
+    {
+        var extension = Extension;
+
+        // If null or ignore roof is false
+        if (extension is not { ignoreRoofCheck: true })
+        {
+            // Check if starting under the roof
+            if (!WingedFlyer.IsCellValid(CasterPawn.Position, Caster.Map, true))
+            {
+                // Don't show messages/play sounds unless showMessages is true to prevent sounds without user input
+                if (showMessages)
+                {
+                    // Translate the text (if possible) and display a message, else just play a rejection sound
+                    if (!(extension?.underRoofStartKey).NullOrEmpty())
+                        Messages.Message(extension!.underRoofStartKey.Translate(CasterPawn.Named("PAWN")), CasterPawn, MessageTypeDefOf.RejectInput, false);
+                    else
+                        SoundDefOf.ClickReject.PlayOneShotOnCamera();
+                }
+                return false;
+            }
+
+            // Check if ending under the roof
+            if (!WingedFlyer.IsCellValid(target.Cell, Caster.Map, true))
+            {
+                // Don't show messages/play sounds unless showMessages is true to prevent sounds without user input
+                if (showMessages)
+                {
+                    // Translate the text (if possible) and display a message, else just play a rejection sound
+                    if (!(extension?.underRoofEndKey).NullOrEmpty())
+                        Messages.Message(extension!.underRoofEndKey.Translate(CasterPawn.Named("PAWN")), CasterPawn, MessageTypeDefOf.RejectInput, false);
+                    else
+                        SoundDefOf.ClickReject.PlayOneShotOnCamera();
+                }
+                return false;
+            }
+        }
+
+        return base.ValidateTarget(target, showMessages);
+    }
+}

--- a/1.5/Source/DDLib/Abilities/CannotUseWhileFormingCaravanExtension.cs
+++ b/1.5/Source/DDLib/Abilities/CannotUseWhileFormingCaravanExtension.cs
@@ -1,0 +1,19 @@
+﻿using RimWorld.Planet;
+using Verse;
+using VFECore.Abilities;
+
+namespace DD;
+
+public class CannotUseWhileFormingCaravanExtension : AbilityExtension_AbilityMod
+{
+    public string disableMessageKey = "Ability_CannotUseWhileFormingCaravan";
+
+    public override bool IsEnabledForPawn(Ability ability, out string reason)
+    {
+        if (ability.CasterPawn == null || !ability.CasterPawn.IsFormingCaravan())
+            return base.IsEnabledForPawn(ability, out reason);
+
+        reason = disableMessageKey.Translate(ability.CasterPawn.LabelCap.Named("PAWN"));
+        return false;
+    }
+}

--- a/1.5/Source/DDLib/Abilities/RequireBodyPartExtension.cs
+++ b/1.5/Source/DDLib/Abilities/RequireBodyPartExtension.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Verse;
+using VFECore.Abilities;
+
+namespace DD;
+
+public class RequireBodyPartExtension : AbilityExtension_AbilityMod
+{
+    public BodyPartDef bodyPart;
+    public bool missing;
+    public IntRange partCount = IntRange.one;
+    public string disableMessageKey = "Ability_RequiresBodyPart";
+
+    //Get all missing parts if we're evaluating missing parts. Non-missing otherwise.
+    private IEnumerable<BodyPartRecord> GetIntendedBodyParts(Pawn pawn) => AbilityComp_RequireBodyPart.CollectRecords(pawn.def.race.body.corePart, bodyPart).Where(rec => missing == pawn.health.hediffSet.PartIsMissing(rec));
+    private int CountBodyParts(Pawn pawn) => GetIntendedBodyParts(pawn).Count(part => part.def == bodyPart);
+    public bool ConditionSatisfied(Pawn pawn) => CountBodyParts(pawn) < partCount.TrueMax;
+
+    public override bool IsEnabledForPawn(Ability ability, out string reason)
+    {
+        if (ability.CasterPawn == null || ConditionSatisfied(ability.CasterPawn))
+            return base.IsEnabledForPawn(ability, out reason);
+
+        reason = disableMessageKey.Translate(ability.CasterPawn.LabelCap.Named("PAWN"), CountBodyParts(ability.CasterPawn).Named("COUNT"), bodyPart.LabelCap.Named("BODYPART"));
+        return false;
+    }
+}

--- a/1.5/Source/DDLib/DragonsDescentLibrary.csproj
+++ b/1.5/Source/DDLib/DragonsDescentLibrary.csproj
@@ -37,6 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Abilities\Ability_ShootProjectile_Multiple_Dragon.cs" />
+    <Compile Include="Abilities\Ability_WingedFlyer.cs" />
+    <Compile Include="Abilities\CannotUseWhileFormingCaravanExtension.cs" />
     <Compile Include="Abilities\Charge\AbilityStraightPawnFlyer.cs" />
     <Compile Include="Abilities\CompAbilityEffect_Burner_DragonFire.cs" />
     <Compile Include="Abilities\CompAbilityEffect_Burner_DragonNecro.cs" />
@@ -48,6 +50,7 @@
     <Compile Include="Abilities\Ability_Explode_Fire.cs" />
     <Compile Include="Abilities\Gainabilities.cs" />
     <Compile Include="Abilities\ProjectileMultiple.cs" />
+    <Compile Include="Abilities\RequireBodyPartExtension.cs" />
     <Compile Include="Abilities\Stance\DD_Stance_Stand.cs" />
     <Compile Include="Buildings\Incubation\Graphics\LayeredGraphicData.cs" />
     <Compile Include="Buildings\Incubation\Graphics\Graphic_Multi_Layered.cs" />
@@ -340,6 +343,8 @@
     <Compile Include="FW\Verb\Verb_Shoot_Limited.cs" />
     <Compile Include="UI\UI.cs" />
     <Compile Include="Verb\IncineratorSpray_Dragon.cs" />
+    <Compile Include="Flight\WingedFlyer.cs" />
+    <Compile Include="Flight\WingedFlyerExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/1.5/Source/DDLib/FW/Abilities/Comps/AbilityComp_RequireBodyPart.cs
+++ b/1.5/Source/DDLib/FW/Abilities/Comps/AbilityComp_RequireBodyPart.cs
@@ -14,7 +14,7 @@ namespace DD
     {
         public AbilityCompProperties_RequireBodyPart VProps => props as AbilityCompProperties_RequireBodyPart;
 
-        private static IEnumerable<BodyPartRecord> CollectRecords(BodyPartRecord record, BodyPartDef part, List<BodyPartRecord> records = null)
+        public static IEnumerable<BodyPartRecord> CollectRecords(BodyPartRecord record, BodyPartDef part, List<BodyPartRecord> records = null)
         {
             if (records == null)
             {

--- a/1.5/Source/DDLib/Flight/WingedFlyer.cs
+++ b/1.5/Source/DDLib/Flight/WingedFlyer.cs
@@ -89,11 +89,11 @@ namespace DD
 
                     if (Variants != null)
                     {
-                        graphic = Variants.Where(variant => variant.variantPath == InnerPawn.Drawer.renderer.graphics.nakedGraphic.path).Select(variant => variant.variantData.GetGraphic(DefaultGraphicData.Graphic)).FirstOrFallback();
+                        graphic = Variants.Where(variant => variant.variantPath == InnerPawn.Drawer.renderer.BodyGraphic.path).Select(variant => variant.variantData.GetGraphic(DefaultGraphicData.Graphic)).FirstOrFallback();
 
                         if (graphic == null)
                         {
-                            Log.Warning("Unable to find flying variant for [" + InnerPawn.Drawer.renderer.graphics.nakedGraphic.path + "]");
+                            Log.Warning("Unable to find flying variant for [" + InnerPawn.Drawer.renderer.BodyGraphic.path + "]");
                             graphic = data.GraphicColoredFor(InnerPawn);
                         }
                     }
@@ -116,7 +116,7 @@ namespace DD
             }
         }
 
-        public override void DrawAt(Vector3 drawLoc, bool flip = false)
+        protected override void DrawAt(Vector3 drawLoc, bool flip = false)
         {
             if (InnerPawn != null)
             {
@@ -200,7 +200,7 @@ namespace DD
             //Rotation = Rot4.FromAngleFlat(Position.AngleFlat - dest.AngleFlat);
         }
 
-        public static WingedFlyer MakeFlyer(Pawn pawn, TargetInfo dest)
+        public static WingedFlyer MakeFlyer(Pawn pawn, TargetInfo dest, ThingDef flyerDef)
         {
             if (!pawn.def.HasModExtension<WingedFlyerExtension>())
             {
@@ -216,8 +216,10 @@ namespace DD
 
             IntVec3 pos = pawn.Position;
             Map map = pawn.Map;
+            // Check if the pawn was selected before flying
+            bool isSelected = Find.Selector.IsSelected(pawn);
 
-            WingedFlyer flyer = (WingedFlyer)ThingMaker.MakeThing(DD_ThingDefOf.WingedFlyer);
+            WingedFlyer flyer = (WingedFlyer)ThingMaker.MakeThing(flyerDef);
 
             flyer.start = pos;
             flyer.dest = dest.Cell;
@@ -227,6 +229,9 @@ namespace DD
             if (affectedPawns.All(p => flyer.container.TryAddOrTransfer(p)))
             {
                 GenSpawn.Spawn(flyer, pos, map);
+                // Re-select the pawn after creating the flyer, matching vanilla behavior
+                if (isSelected)
+                    Find.Selector.Select(pawn);
 
                 return flyer;
             }

--- a/1.5/Source/DDLib/Flight/WingedFlyerExtension.cs
+++ b/1.5/Source/DDLib/Flight/WingedFlyerExtension.cs
@@ -1,25 +1,34 @@
-﻿// using System;
-// using System.Collections.Generic;
-// using System.Linq;
-// using System.Text;
-// using System.Threading.Tasks;
-// using Verse;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
 
-// namespace DD
-// {
-//     public class WingedFlyerVariant
-//     {
-//         public string variantPath;
-//         public AlternateGraphic variantData;
-//     }
+namespace DD
+{
+    public class WingedFlyerVariant
+    {
+        public string variantPath;
+        public AlternateGraphic variantData;
+    }
 
-//     public class WingedFlyerExtension : DefModExtension
-//     {
-//         public float flightSpeed;
-//         public GraphicData flyingGraphicData;
-//         public List<WingedFlyerVariant> variants;
+    public class WingedFlyerExtension : DefModExtension
+    {
+        public float flightSpeed;
+        public GraphicData flyingGraphicData;
+        public List<WingedFlyerVariant> variants;
 
-//         public SimpleCurve travelFlightCurve;
-//         public float minimumWeight;
-//     }
-// }
+        public SimpleCurve travelFlightCurve;
+        public float minimumWeight;
+    }
+
+    public class WingedFlyerAbilityExtension : DefModExtension
+    {
+        public ThingDef flyerDef;
+
+        public bool ignoreRoofCheck = false;
+        public string underRoofStartKey;
+        public string underRoofEndKey;
+    }
+}


### PR DESCRIPTION
Current changes/additions:
- Made `WingedFlyer` and `WingedFlyerExtension` compile again (added them to .csproj)
- Added `Ability_WingedFlyer`, which is the VFE ability that creates the flyer
  - It also handles checks if the starting/end tile are valid (unroofed)
- Added `WingedFlyerAbilityExtension` to `WingedFlyerExtension` file
  - It acts as an `DefModExtension` to the VFE ability
  - It allows to specify a `ThingDef` for the flyer
  - It allows to enable/disable the roof check and specify a custom message when using the abilitty while roofed/targeting roofed tile
- Fixed issues with `WingedFlyer`
  - Changed the checked body path to work in 1.5
  - Changed `DrawAt` from protected to public
- Changed `WingedFlyer.MakeFlyer` to accept a `ThingDef` as an argument
- Changed `WingedFlyer.MakeFlyer` to re-select the selected pawn when spawning the flyer (matching vanilla behavior)
- Added `DD_DraconicFlight` ability for VFE winged flyer
  - I've attempted to copy the original winged flyer as closely as possible, wherever possible
- Added `RequireBodyPartExtension` for VFE abilities (matching `AbilityComp_RequireBodyPart` from the old flyer)
- Made `AbilityComp_RequireBodyPart.CollectRecords` method public, as it's required by `RequireBodyPartExtension` (to avoid code repetition)
- Added `CannotUseWhileFormingCaravanExtension` for VFE abilities (matching behavior from the old flyer)
- Added translation keys and English translation needed for all the new code
- Uncommented all the `DD.WingedFlyerExtension` in XML files
- Gave all dragons `DD_DraconicFlight` ability