### PR TITLE
Added ability extensions for minimum age and disabled ability

### DIFF
--- a/1.5/Defs/AbilityDefs/Abilites/DragonBreath_VFECore.Abilities.xml
+++ b/1.5/Defs/AbilityDefs/Abilites/DragonBreath_VFECore.Abilities.xml
@@ -83,6 +83,10 @@
         <range>30</range>
         <cooldownTime>1250</cooldownTime>
         <iconPath>UserInterface/Abilities/Fly</iconPath>
+        <showUndrafted>true</showUndrafted>
+        <modExtensions>
+            <li Class="DD.DisabledAbilityExtension" />
+        </modExtensions>
       </VFECore.Abilities.AbilityDef>
       <!-- 
       <VFECore.Abilities.AbilityDef>
@@ -262,6 +266,9 @@
             <!-- Prevent use of the ability while forming caravan, just like it worked in the past. -->
             <!-- disableMessageKey will default to Ability_CannotUseWhileFormingCaravan -->
             <li Class="DD.CannotUseWhileFormingCaravanExtension" />
+            <li Class="DD.MinimumAgeExtension" >
+                <minAge>35</minAge>
+            </li>
         </modExtensions>
     </VFECore.Abilities.AbilityDef>
 

--- a/1.5/Languages/English/Keyed/Abilities.xml
+++ b/1.5/Languages/English/Keyed/Abilities.xml
@@ -12,5 +12,6 @@
 	<Ability_CannotUseWhileFormingCaravan>{PAWN} cannot use this ability while forming a caravan.</Ability_CannotUseWhileFormingCaravan>
 	<Ability_CannotStartFlyingUnderRoof>Cannot fly when under a roof.</Ability_CannotStartFlyingUnderRoof>
 	<Ability_CannotEndFlyingUnderRoof>Cannot target a roofed tile.</Ability_CannotEndFlyingUnderRoof>
+	<Ability_UnderMinimumAge>{PAWN} needs to be at least {AGE} to use this ability.</Ability_UnderMinimumAge>
 	
 </LanguageData>

--- a/1.5/Source/DDLib/Abilities/Charge/Ability_DragonJump.cs
+++ b/1.5/Source/DDLib/Abilities/Charge/Ability_DragonJump.cs
@@ -35,11 +35,6 @@ namespace DD
                 //}, "DragonJumpAbility", false, null);
             }, "DragonJumpAbility", false, null);
         }
-
-        public override bool ShowGizmoOnPawn()
-        {
-            return this.pawn != null && this.pawn.Faction == Faction.OfPlayer;
-        }
     }
 
 

--- a/1.5/Source/DDLib/Abilities/DisabledAbilityExtension.cs
+++ b/1.5/Source/DDLib/Abilities/DisabledAbilityExtension.cs
@@ -1,0 +1,20 @@
+﻿using RimWorld.Planet;
+using Verse;
+using VFECore.Abilities;
+
+namespace DD;
+
+public class DisabledAbilityExtension : AbilityExtension_AbilityMod
+{
+    public override bool ShowGizmoOnPawn(Pawn pawn) => false;
+    public override bool IsEnabledForPawn(Ability ability, out string reason)
+    {
+        reason = "Hidden/disabled ability - you should not be able to see this.";
+        return false;
+    }
+    // Those are likely not needed, but may as well be 100% sure the AI can't use it.
+    public override bool Valid(GlobalTargetInfo[] targets, Ability ability, bool throwMessages = false) => false;
+    public override bool ValidateTarget(LocalTargetInfo target, Ability ability, bool throwMessages = false) => false;
+    public override bool ValidTile(GlobalTargetInfo target, Ability ability, bool throwMessages = false) => false;
+    public override bool CanApplyOn(LocalTargetInfo target, Ability ability, bool throwMessages = false) => false;
+}

--- a/1.5/Source/DDLib/Abilities/MinimumAgeExtension.cs
+++ b/1.5/Source/DDLib/Abilities/MinimumAgeExtension.cs
@@ -1,0 +1,21 @@
+﻿using Verse;
+using VFECore.Abilities;
+
+namespace DD;
+
+public class MinimumAgeExtension : AbilityExtension_AbilityMod
+{
+    public int minAge = 0;
+    public string underMinAgeKey = "Ability_UnderMinimumAge";
+
+    public override bool IsEnabledForPawn(Ability ability, out string reason)
+    {
+        if (ability.CasterPawn.ageTracker.AgeBiologicalYears < minAge)
+        {
+            reason = underMinAgeKey.Translate(ability.CasterPawn.Named("PAWN"), minAge.Named("AGE"));
+            return false;
+        }
+
+        return base.IsEnabledForPawn(ability, out reason);
+    }
+}

--- a/1.5/Source/DDLib/DragonsDescentLibrary.csproj
+++ b/1.5/Source/DDLib/DragonsDescentLibrary.csproj
@@ -48,7 +48,9 @@
     <Compile Include="Abilities\Charge\Ability_DragonJump.cs" />
     <Compile Include="Abilities\Ability_ShootProjectile_Dragon.cs" />
     <Compile Include="Abilities\Ability_Explode_Fire.cs" />
+    <Compile Include="Abilities\DisabledAbilityExtension.cs" />
     <Compile Include="Abilities\Gainabilities.cs" />
+    <Compile Include="Abilities\MinimumAgeExtension.cs" />
     <Compile Include="Abilities\ProjectileMultiple.cs" />
     <Compile Include="Abilities\RequireBodyPartExtension.cs" />
     <Compile Include="Abilities\Stance\DD_Stance_Stand.cs" />


### PR DESCRIPTION
- MinimumAgeExtension will disable the ability for pawns under the minimum required age
  - Added translation key for the message if under the required age
  - Added minimum age for flight as 35
- DisabledAbilityExtension will unconditionally disable and hide the gizmo for an ability (either temporarily or permanently)
  - Added to Dragon Jump, as I believe it (at least for now) is not going to be used for the dragons
- Removed `Ability_DragonJump.ShowGizmoOnPawn`, as it had some issues and prevented `DisabledAbilityExtension` from working
  - Having a custom `ShowGizmoOnPawn` should not be needed for animals if a pawn is draftable (due to VEF patches) - and since all dragons are draftable it should not be a problem
    - [VEF patch that allows gizmos on draftable pawns](https://github.com/Vanilla-Expanded/VanillaExpandedFramework/blob/f4910bd8891807c77cb26f9179b1b1a805f81445/Source/VFECore/AnimalBehaviours/Harmony/Draftability/Pawn_IsColonistPlayerControlled_Patch.cs)
  - It caused issues when a pawn wasn't spawned (for example, flying, being carried) as the gizmo would still be active and visible
  - Set `showUndrafted` to true for Dragon Jump ability, to match the previous behavior (before removing the method)
  - If a custom ShowGizmoOnPawn method is desired, I could include one that would work better in more situations (include extra checks if it should be visible)